### PR TITLE
Workaround to check monaco editor initialization

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -83,7 +83,8 @@
                 onchange: function(tab) {
                     $("#func-tabs-content").children().hide();
                     $("#" + tab.id).show();
-                    RED.tray.resize();
+                    let editor = $("#" + tab.id).find('.node-text-editor').first();                  
+                   	if(!editor.is(':empty')) RED.tray.resize();                   	
                 }
             });
             tabs.addTab({


### PR DESCRIPTION
Check if the editor has already been initialized to avoid multiple call to resize() function before it will be ready.